### PR TITLE
Git ignore /dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+/dist/


### PR DESCRIPTION
The /dist folder is generated by the Grunt runner, should not be tracked