### PR TITLE
changed tabs in menu. Moved modules to appropriate tabs

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -34,11 +34,12 @@
 		</svg>
   </span>
   	</li>
-    <li class="tab "><a class="active" href="#tab-home"><i class="material-icons right">timeline</i>Home</a></li>
-    <li class="tab"><a href="#tab-development"><i class="material-icons right">dvr</i>Development</a></li>
-    <li class="tab"><a href="#tab-personal"><i class="material-icons right">perm_identity</i>Personal overview</a></li>
+    <li class="tab "><a href="#tab-dashboard"><i class="material-icons right">view_compact</i>Dashboard</a></li>
+    <li class="tab"><a class="active" href="#tab-personal"><i class="material-icons right">perm_identity</i>Personal overview</a></li>
+    <li class="tab"><a href="#tab-behaviour"><i class="material-icons right">touch_app</i>Behaviour</a></li>
     <li class="tab"><a href="#tab-project"><i class="material-icons right">developer_board</i>Project overview</a></li>
-    <li class="tab"><a href="#tab-settings"><i class="material-icons right">build</i>Settings</a></li>
+    <li class="tab"><a href="#tab-development"><i class="material-icons right">dvr</i>Development</a></li>
+    <!-- <li class="tab"><a href="#tab-settings"><i class="material-icons right">build</i>Settings</a></li> -->
   </ul>
   <ul class="show-on-med-and-down">
   	<li id="AppName">Octopeer</li>
@@ -46,34 +47,45 @@
 </nav>
 
  <main > 
-	<div id="tab-home" class="tab-pane fade in active">
-        <div id="bodyrow" class="row">
+	<div id="tab-dashboard" class="container">
+        <div id="dashboard-modules" class="row">
+        </div>
+        <div class="card-panel">
+            There is no content available yet in the <strong>dashboard</strong>.
+        </div>
+    </div>
+
+    <div id="tab-personal" >
+        <div id="personal-modules" class="row">
+        </div>
+    </div>
+
+    <div id="tab-behaviour" class="container">
+        <div id="behaviour-modules" class="row">
+        </div>
+        <div class="card-panel">
+        There is no content available yet in the <strong>behaviour</strong> page.
+        </div>
+    </div>
+
+    <div id="tab-project" >
+        <div id="project-modules" class="row">
         </div>
     </div>
 
     <div id="tab-development" class="container">
+        <div id="development-modules" class="row">
+        </div>
         <div class="card-panel">
             There is no content available yet in the <strong>development</strong> page.
         </div>
     </div>
 
-    <div id="tab-personal" class="container">
-        <div class="card-panel">
-        There is no content available yet in the <strong>personal overview</strong> page.
-        </div>
-    </div>
-
-    <div id="tab-project" class="container">
-        <div class="card-panel">
-        There is no content available yet in the <strong>project overview</strong> page.
-        </div>
-    </div>
-
-    <div id="tab-settings" class="container">
+    <!-- <div id="tab-settings" class="container">
         <div class="card-panel">
         There is no content available yet in the <strong>settings</strong> page.
         </div>
-    </div>
+    </div> -->
 </main>
     </body>
 </html>

--- a/src/modules/average-comment-size-compared.js
+++ b/src/modules/average-comment-size-compared.js
@@ -4,7 +4,7 @@ define(function () {
     	name: "average-comment-size-compared",
         title: "Average comment sizes",
     	size: 1,
-        parentSelector: "#bodyrow",
+        parentSelector: "#personal-modules",
         xAxisLabel: "Average comment size (size/count)",
         yAxisLabel: "Pull request",
         xAxisLine: true,

--- a/src/modules/average-comment-size-total.js
+++ b/src/modules/average-comment-size-total.js
@@ -4,7 +4,7 @@ define(function () {
     	name: "average-comment-size-total",
         title: "Total average comment size",
     	size: 1,
-        parentSelector: "#bodyrow",
+        parentSelector: "#project-modules",
         xAxisLabel: "Average comment size (size/count)",
         yAxisLabel: "Pull request",
         xAxisLine: true,

--- a/src/modules/average-comment-size-yours.js
+++ b/src/modules/average-comment-size-yours.js
@@ -4,7 +4,7 @@ define(function () {
     	name: "average-comment-size-yours",
         title: "Your average comment size",
     	size: 1,
-        parentSelector: "#bodyrow",
+        parentSelector: "#personal-modules",
         xAxisLabel: "Average comment size (size/count)",
         yAxisLabel: "Pull request",
         xAxisLine: true,

--- a/src/modules/graph1.js
+++ b/src/modules/graph1.js
@@ -4,7 +4,7 @@ define(function () {
         name: 'graph1',
         title: 'Number of pull-request per number of comments',
         size: 1,
-        parentSelector: '#bodyrow',
+        parentSelector: '#project-modules',
         xAxisLabel: "Number of comments",
         yAxisLabel: "Number of pull-requests",
         yRightAxisLabel: "",

--- a/src/modules/pr-size.js
+++ b/src/modules/pr-size.js
@@ -4,7 +4,7 @@ define(function () {
     	name: "pr-size",
         title: "Size of pr",
     	size: 1,
-        parentSelector: "#bodyrow",
+        parentSelector: "#project-modules",
         xAxisLabel: "Number of lines changed",
         yAxisLabel: "Pull request",
         xAxisLine: true,

--- a/src/modules/pull-requests.js
+++ b/src/modules/pull-requests.js
@@ -7,7 +7,7 @@ define(function () {
         name: "pull-requests",
         title: "Pull requests",
         size: 1,
-        parentSelector: "#bodyrow",
+        parentSelector: "#project-modules",
         xAxisLabel: "Date",
         yAxisLabel: "",
         yAxis: false,

--- a/src/modules/time-and-pr-size.js
+++ b/src/modules/time-and-pr-size.js
@@ -4,7 +4,7 @@ define(function () {
     	name: "time-and-pr-size",
         title: "Time spent + size pr",
     	size: 1,
-        parentSelector: "#bodyrow",
+        parentSelector: "#personal-modules",
         yRightAxis: true,
         xAxisLabel: "Number of lines changed",
         yAxisLabel: "Pull request",

--- a/src/modules/time.js
+++ b/src/modules/time.js
@@ -4,7 +4,7 @@ define(function () {
     	name: "time",
         title: "Time spent on pr",
     	size: 1,
-        parentSelector: "#bodyrow",
+        parentSelector: "#personal-modules",
         xAxisLabel: "Time spent on pr",
         yAxisLabel: "Pull request",
         xAxisLine: true,


### PR DESCRIPTION
Removed settings tab and added dasboard and behaviour tabs.

Tabs at the moment are, 
Dashboard : Most important modules can be shown here as a landing page.
Personal overview : Data on user (general); Length of  reviewed PRs, size of reviewed PRs, etc. 
Behaviour : Actual behaviour data of user (during PR); Mouse movements, actions during PR, etc.
Project overview : Information on repositories and PRs; open PRs, size op all PRs, number of comments on all PRs, etc.
Development : Personal development information; own open PRs, own number of lines added to PR, etc.

Let me know if we should handle this differently.
