### PR TITLE
Fix session start end events

### DIFF
--- a/src/aggregators/dashboardAggregator.js
+++ b/src/aggregators/dashboardAggregator.js
@@ -77,12 +77,14 @@ function DashboardAggregator(userName) {
                     sessionEndId = endEvent.session.id;
                     if (sessionStartId === sessionEndId) {
                         pr.sessionEnds.splice(i, 1);
-                        pr.totalDuration += sessionEndDate - sessionStartDate;
+                        if (sessionEndDate > sessionStartDate) {
+                            pr.totalDuration += sessionEndDate - sessionStartDate;
+                        }
                         break;
                     }
                 }
             });
-            pr.totalDuration = pr.totalDuration / 1000;
+            pr.totalDuration = Math.ceil(pr.totalDuration / 1000 / 60);
         });
         return pullRequests;
     }

--- a/src/aggregators/dashboardAggregator.js
+++ b/src/aggregators/dashboardAggregator.js
@@ -12,6 +12,7 @@ function DashboardAggregator(userName) {
             counter = 0,
             startEvents = startAndEndEvents[0],
             endEvents = startAndEndEvents[1];
+        console.log(startAndEndEvents);
         startEvents.forEach(function (event) {
             if (!dictionary.hasOwnProperty(event.session.pull_request.url)) {
                 dictionary[event.session.pull_request.url] = counter;
@@ -38,7 +39,7 @@ function DashboardAggregator(userName) {
             pullRequests.forEach(function (pr) {
                 events.forEach(function (event) {
                     if (event.session.pull_request.url === pr.url) {
-                        pr["closedByYou"] = true;
+                        pr.closedByYou = true;
                     }
                 });
             });
@@ -46,28 +47,42 @@ function DashboardAggregator(userName) {
         });
     }
     
+    function orderEvents(pullRequests) {
+        pullRequests.forEach(function (pr) {
+            pr.sessionStarts = pr.sessionStarts.sort(function (a, b) {
+                return new Date(a.created_at) - new Date(b.created_at);
+            });
+            pr.sessionEnds = pr.sessionEnds.sort(function (a, b) {
+                return new Date(a.created_at) - new Date(b.created_at);
+            });
+        });
+        return pullRequests;
+    }
+    
     function sumDurationOfSessionsFromPullRequests(pullRequests) {
+        var sessionStartId,
+            endEvent,
+            sessionEndId,
+            i,
+            sessionStartDate,
+            sessionEndDate;
         pullRequests.forEach(function (pr) {
             pr.totalDuration = 0;
-            pr.sessionStarts.forEach(function (session) {
-                var endSessionFound = false;
-                pr.sessionEnds.forEach(function (sessionEnd) {
-                    if (session.session.id === sessionEnd.session.id) {
-                        var endDate = new Date(sessionEnd.created_at);
-                        var startDate = new Date(session.created_at);
-                        if (endDate > startDate) {
-                            pr.totalDuration = endDate - startDate;
-                        } else {
-                            pr.totalDuration = 10000;
-                        }
-                        endSessionFound = true;
+            pr.sessionStarts.forEach(function (se) {
+                sessionStartId = se.session.id;
+                sessionStartDate = new Date(se.created_at);
+                for (i = 0; i < pr.sessionEnds.length; i += 1) {
+                    endEvent = pr.sessionEnds[i];
+                    sessionEndDate = new Date(endEvent.created_at);
+                    sessionEndId = endEvent.session.id;
+                    if (sessionStartId === sessionEndId) {
+                        pr.sessionEnds.splice(i, 1);
+                        pr.totalDuration += sessionEndDate - sessionStartDate;
+                        break;
                     }
-                });
-                if (!endSessionFound) {
-                    pr.totalDuration = 1000;
                 }
-                pr.totalDuration = pr.totalDuration / 1000;
             });
+            pr.totalDuration = pr.totalDuration / 1000;
         });
         return pullRequests;
     }
@@ -79,17 +94,17 @@ function DashboardAggregator(userName) {
         graphObject.sessions = graphObject.sessions.concat(pullRequests.map(function (pr) {
             var state = "0";
             if (pr.prInfo.state === "merged") {
-                state = "1";
-            } else if (pr.prInfo.state === "closed") {
                 state = "2";
+            } else if (pr.prInfo.state === "closed") {
+                state = "1";
             }
             if (pr.prInfo.hasOwnProperty("merged_by")) {
                 if (pr.prInfo.merged_by === userName) {
                     state = "11";
-                }  
+                }
             } else if (pr.closedByYou) {
                 state = "21";
-            } 
+            }
             return {
                 "id": "1",
                 "type": "pr",
@@ -109,6 +124,7 @@ function DashboardAggregator(userName) {
             .then(createPullRequestsObjectFromSessions)
             .then(prResolver.resolvePullRequests)
             .then(checkIfClosedByUser)
+            .then(orderEvents)
             .then(sumDurationOfSessionsFromPullRequests)
             .then(convertToGraphObject)
             .then(fulfill);

--- a/src/aggregators/punchCardAggregator.js
+++ b/src/aggregators/punchCardAggregator.js
@@ -16,20 +16,8 @@ function PunchCardAggregator(userName) {
             });
     }
     
-    function setSemanticEvents(startEndEvents) {
-        startEndEvents.startEvents.forEach(function (se) {
-            octopeerService.getSemanticEventsOfPullRequest(userName,
-                                                          se.session.pull_request.repository.owner,
-                                                          se.session.pull_request.repository.name,
-                                                          se.session.pull_request.pull_request_number)
-                .then(function (events) {
-                    se.session.pull_request.semanticEvents = events;
-                });
-        });
-        return startEndEvents;
-    }
-    
     function orderEvents(startEndEvents) {
+        console.log(startEndEvents);
         startEndEvents.startEvents = startEndEvents.startEvents.sort(function (a, b) {
             return new Date(a.created_at) - new Date(b.created_at);
         });
@@ -66,7 +54,6 @@ function PunchCardAggregator(userName) {
             }
             return obj;
         });
-        console.log(graphObject);
         return graphObject;
     }
     

--- a/src/modules/punch-card.js
+++ b/src/modules/punch-card.js
@@ -1,4 +1,4 @@
-/* globals define, PunchCardAggregator */
+/* globals define, PunchCardAggregator, globalUserName */
 /* jshint unused : vars*/
 
 define(function () {
@@ -51,10 +51,11 @@ define(function () {
         xAxisFitFunction: false,
         yAxisFitFunction: false,
         data: [{
-            "serviceCall": function () { return new PunchCardAggregator("Travis", 20); },
+            "serviceCall": function () { return new PunchCardAggregator(globalUserName, 20); },
             "required": true
         }],
         body: function (res) {
+            console.log(res[0]);
             // given a day gets the amount of days that have passed since then.
             function transformDay(day) {
                 return (today + 7 - day) % 7;


### PR DESCRIPTION
The start and end events parts in the dashboard and punchcard were wrong. I have fixed this. But there is still the problem that i cannot connect the start and end events together, which still results in weird results.

But we will talk about that in the meeting monday

@lvdoorn Can you maybe change the color of the start and end events in the punch card? This way we know what dot a start pull request is and what dot an end pull request is, which might improve the graph a bit.