### PR TITLE
tooltips now higher z-index than menu

### DIFF
--- a/libs/d3.v2.min.js
+++ b/libs/d3.v2.min.js
@@ -233,7 +233,7 @@ n){return arguments.length?(t=+n,e):t},e.translate=function(t){return arguments.
         position: 'absolute',
         top: 0,
         //opacity: 0,
-        display:'initial',
+        display:'none',
         //'pointer-events': 'none',
         'box-sizing': 'border-box'
       })

--- a/src/styles/style.TI2806.css
+++ b/src/styles/style.TI2806.css
@@ -206,6 +206,7 @@ main > div.tab-pane > div.row {
     padding: 5px 15px;
     border-radius: 4px;
     box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12);
+    z-index: 999;
 }
 
 .d3-tip > .arrow-left{


### PR DESCRIPTION
Wide tooltips could go under the menu bar on the left. Now they have a z-index of 999. The initial display state of the tooltips were initial, allowing them to be seen in the top left corner when not used, so changed that into none in the lib file to hide it from the start.